### PR TITLE
Various fixes to documentation related to writing a new model for a study

### DIFF
--- a/climateeconomics/sos_wrapping/sos_wrapping_witness/population/documentation/population_discipline.md
+++ b/climateeconomics/sos_wrapping/sos_wrapping_witness/population/documentation/population_discipline.md
@@ -29,7 +29,6 @@ The function looks like:
  ![](knowledgefunction.png)  
 
 And then: 
-
 $$birth\_rate(knowledge)_t = c + \alpha * (1- \frac{knowledge_t}{100})^{\beta}$$
 with $c$, $\alpha$ and $\beta$ the parameters obtained by the fitting of the full birth rate function.   
 For the second part we follow McIsaac (2017)[^1]:

--- a/climateeconomics/sos_wrapping/sos_wrapping_witness/population/documentation/population_discipline.md
+++ b/climateeconomics/sos_wrapping/sos_wrapping_witness/population/documentation/population_discipline.md
@@ -58,7 +58,7 @@ death\_rate_{i, t} = dr\_upper_i + \frac{dr\_lower_i - dr\_upper_i}{(1 + \exp(-\
 ```
 where $Y_t$ represents the GDP, $N_t$ the total population at year $t$, $dr{\textunderscore}upper$ and $dr{\textunderscore}lower$ the upper and lower asymptotes, $\delta$ a slope parameter, $\phi$ is the GWP/capita value determining the inflection point and $\nu$ is a parameter that controls the curvature of the function near the asymptotes.
 
-Death rate is also impacted by climate in four principal ways, global warming affects crops by reducing yields and the micro/macronutrients contents of cereals, favors allergens and vector-borne infectious diseases such as malaria or dengue, increases risks of diarrheal diseases due to heat waves causing reduced access to safe water, and increases probability of heat waves that causes higher mortality related to cardiovasculare or chronic respiratory diseases [^2]. It is modelized following excess mortality function associated with climate change:
+Death rate is also impacted by climate in four principal ways, global warming affects crops by reducing yields and the micro/macronutrients contents of cereals, favors allergens and vector-borne infectious diseases such as malaria or dengue, increases risks of diarrheal diseases due to heat waves causing reduced access to safe water, and increases probability of heat waves that causes higher mortality related to cardiovasculare or chronic respiratory diseases[^2]. It is modelized following excess mortality function associated with climate change:
 ```math
 \widetilde{DR}_i = {DR}_i [ 1 + \sum_{\mathclap{j \in J}} \alpha_{i,j} (\frac{T}{T^0})^{\theta}]
 ```
@@ -69,7 +69,7 @@ $$\beta_i := \sum_{\mathclap{j \in J}} \alpha_{i,j}$$
 
 ![](climate_death_multipliers.PNG)
 
-Finally [^10], death rate is impacted by average calorie intake and deviating from a parametrable reference value will have a significant impact on death rate in both ways. Death rate age range is impacted differently whether the average calorie intake rises or decreases: younger people will be more impacted by undernutrition whereas older one by overnutrition due to cardiovascular deseases [^11]. It is modelized such as:
+Finally[^10], death rate is impacted by average calorie intake and deviating from a parametrable reference value will have a significant impact on death rate in both ways. Death rate age range is impacted differently whether the average calorie intake rises or decreases: younger people will be more impacted by undernutrition whereas older one by overnutrition due to cardiovascular deseases[^11]. It is modelized such as:
 ```math
 DR_i = \widetilde{DR}_i + \overline{DR}_i
 ```
@@ -161,4 +161,8 @@ The following graphs show the results of our birth rate fitting:
 
 [^8]: Our world in data. Literate and illiterate world population. Available at: https://ourworldindata.org/grapher/literate-and-illiterate-world-population?country=~OWID_WRL
 
-[^9]: Vollset, S.E., Goren, E., Yuan, C.W., Cao, J., Smith, A.E., Hsiao, T., Bisignano, C., Azhar, G.S., Castro, E., Chalek, J. and Dolgert, A.J., 2020. Fertility, mortality, migration, and population scenarios for 195 countries and territories from 2017 to 2100: a forecasting analysis for the Global Burden of Disease Study. The Lancet, 396(10258), pp.1285-1306. 
+[^9]: Vollset, S.E., Goren, E., Yuan, C.W., Cao, J., Smith, A.E., Hsiao, T., Bisignano, C., Azhar, G.S., Castro, E., Chalek, J. and Dolgert, A.J., 2020. Fertility, mortality, migration, and population scenarios for 195 countries and territories from 2017 to 2100: a forecasting analysis for the Global Burden of Disease Study. The Lancet, 396(10258), pp.1285-1306.
+
+[^10]: MISSING REFERENCE
+
+[^11]: MISSING REFERENCE

--- a/climateeconomics/sos_wrapping/sos_wrapping_witness/population/documentation/population_discipline.md
+++ b/climateeconomics/sos_wrapping/sos_wrapping_witness/population/documentation/population_discipline.md
@@ -162,3 +162,5 @@ The following graphs show the results of our birth rate fitting:
 [^8]: Our world in data. Literate and illiterate world population. Available at: https://ourworldindata.org/grapher/literate-and-illiterate-world-population?country=~OWID_WRL
 
 [^9]: Vollset, S.E., Goren, E., Yuan, C.W., Cao, J., Smith, A.E., Hsiao, T., Bisignano, C., Azhar, G.S., Castro, E., Chalek, J. and Dolgert, A.J., 2020. Fertility, mortality, migration, and population scenarios for 195 countries and territories from 2017 to 2100: a forecasting analysis for the Global Burden of Disease Study. The Lancet, 396(10258), pp.1285-1306.
+
+[^10]: MISSING REFERENCE

--- a/climateeconomics/sos_wrapping/sos_wrapping_witness/population/documentation/population_discipline.md
+++ b/climateeconomics/sos_wrapping/sos_wrapping_witness/population/documentation/population_discipline.md
@@ -162,7 +162,3 @@ The following graphs show the results of our birth rate fitting:
 [^8]: Our world in data. Literate and illiterate world population. Available at: https://ourworldindata.org/grapher/literate-and-illiterate-world-population?country=~OWID_WRL
 
 [^9]: Vollset, S.E., Goren, E., Yuan, C.W., Cao, J., Smith, A.E., Hsiao, T., Bisignano, C., Azhar, G.S., Castro, E., Chalek, J. and Dolgert, A.J., 2020. Fertility, mortality, migration, and population scenarios for 195 countries and territories from 2017 to 2100: a forecasting analysis for the Global Burden of Disease Study. The Lancet, 396(10258), pp.1285-1306.
-
-[^10]: MISSING REFERENCE
-
-[^11]: MISSING REFERENCE

--- a/climateeconomics/sos_wrapping/sos_wrapping_witness/population/documentation/population_discipline.md
+++ b/climateeconomics/sos_wrapping/sos_wrapping_witness/population/documentation/population_discipline.md
@@ -29,7 +29,7 @@ Compared to McIsaac (2017)[^1] we added a variable $knowledge$ to the equation. 
 ```math
 knowledge_t =  know\_upper + \frac{know\_lower - know\_upper}{(1 + \exp(-\delta (t - 1800 - \phi)))^{\frac{1}{\nu}}}
 ```
-with t the year at which we estimate the variable, 1800 the first year of the regression. $\usepackage{underscore}\usepackage[T1]{fontenc}know_upper$` and $\usepackage{underscore}\usepackage[T1]{fontenc}know\_lower$ the upper and lower asymptotes, $\delta$ a slope parameter, $\phi$ is the year value determining the inflection point and $\nu$ is a parameter that controls the curvature of the function near the asymptotes. 
+with t the year at which we estimate the variable, 1800 the first year of the regression. $know{\_}upper$ and $know{\_}lower$ the upper and lower asymptotes, $\delta$ a slope parameter, $\phi$ is the year value determining the inflection point and $\nu$ is a parameter that controls the curvature of the function near the asymptotes. 
   
 The function looks like:   
  ![](knowledgefunction.png)  
@@ -43,7 +43,7 @@ For the second part we follow McIsaac (2017)[^1]:
 ```math
 birth\_rate(gdp\_capita)_{15-49, t} = br\_upper + \frac{br\_lower - br\_upper}{(1 + \exp(-\delta (\frac{Y_t}{N_t}-\phi)))^{\frac{1}{\nu}}}
 ```
-where $Y_t$ represents the GDP, $N_t$ the total population at year $t$, $\usepackage{underscore}\usepackage[T1]{fontenc}br\_upper$ and $\usepackage{underscore}\usepackage[T1]{fontenc}br\_lower$ the upper and lower asymptotes, $\delta$ a slope parameter, $\phi$ is the GWP/capita value determining the inflection point and $\nu$ is a parameter that controls the curvature of the function near the asymptotes.  
+where $Y_t$ represents the GDP, $N_t$ the total population at year $t$, $br{\_}upper$ and $br{\_}lower$ the upper and lower asymptotes, $\delta$ a slope parameter, $\phi$ is the GWP/capita value determining the inflection point and $\nu$ is a parameter that controls the curvature of the function near the asymptotes.  
 
 
 ## Death rate 
@@ -56,7 +56,7 @@ Following McIsaac (2017)[^1], and similarly to birth rate, the death rate per ag
 ```math
 death\_rate_{i, t} = dr\_upper_i + \frac{dr\_lower_i - dr\_upper_i}{(1 + \exp(-\delta_i (\frac{Y_t}{N_t} - \phi_i)))^{\frac{1}{\nu_i}}}
 ```
-where $Y_t$ represents the GDP, $N_t$ the total population at year $t$, $\usepackage{underscore}\usepackage[T1]{fontenc}dr\_upper$ and $\usepackage{underscore}\usepackage[T1]{fontenc}dr\_lower$ the upper and lower asymptotes, $\delta$ a slope parameter, $\phi$ is the GWP/capita value determining the inflection point and $\nu$ is a parameter that controls the curvature of the function near the asymptotes.
+where $Y_t$ represents the GDP, $N_t$ the total population at year $t$, $dr{\_}upper$ and $dr{\_}lower$ the upper and lower asymptotes, $\delta$ a slope parameter, $\phi$ is the GWP/capita value determining the inflection point and $\nu$ is a parameter that controls the curvature of the function near the asymptotes.
 
 Death rate is also impacted by climate in four principal ways, global warming affects crops by reducing yields and the micro/macronutrients contents of cereals, favors allergens and vector-borne infectious diseases such as malaria or dengue, increases risks of diarrheal diseases due to heat waves causing reduced access to safe water, and increases probability of heat waves that causes higher mortality related to cardiovasculare or chronic respiratory diseases [^2]. It is modelized following excess mortality function associated with climate change:
 $$\widetilde{DR}_i = {DR}_i [ 1 + \sum_{\mathclap{j \in J}} \alpha_{i,j} (\frac{T}{T^0})^{\theta}]$$

--- a/climateeconomics/sos_wrapping/sos_wrapping_witness/population/documentation/population_discipline.md
+++ b/climateeconomics/sos_wrapping/sos_wrapping_witness/population/documentation/population_discipline.md
@@ -16,7 +16,7 @@ In order to compute the number of deaths and births we use a birth rate and a de
 ## Birth rate 
 According to the United Nation definition, the  age-specific birth rate is the "number of births to women in a particular age group, divided by the number of women in that age group". In our model, we look at the birth rate for the 15-49 age group, the young active population in childbearing age. 
 The birth rate is then: 
-$$birth\_rate_{15-49, t} = \frac{I_{t}}{N_{15-49, t}}$$
+$$birth\\_rate_{15-49, t} = \frac{I_{t}}{N_{15-49, t}}$$
 The birth rate depends on Gross World Product, population and knowledge: 
 $$birth\_rate_{15-49, t} = a.birth\_rate(knowledge)_t + (1-a)*birth\_rate(gdp\_capita)_t$$
 The fitting of this function is explained in the section below.   

--- a/climateeconomics/sos_wrapping/sos_wrapping_witness/population/documentation/population_discipline.md
+++ b/climateeconomics/sos_wrapping/sos_wrapping_witness/population/documentation/population_discipline.md
@@ -59,7 +59,9 @@ death\_rate_{i, t} = dr\_upper_i + \frac{dr\_lower_i - dr\_upper_i}{(1 + \exp(-\
 where $Y_t$ represents the GDP, $N_t$ the total population at year $t$, $dr{\textunderscore}upper$ and $dr{\textunderscore}lower$ the upper and lower asymptotes, $\delta$ a slope parameter, $\phi$ is the GWP/capita value determining the inflection point and $\nu$ is a parameter that controls the curvature of the function near the asymptotes.
 
 Death rate is also impacted by climate in four principal ways, global warming affects crops by reducing yields and the micro/macronutrients contents of cereals, favors allergens and vector-borne infectious diseases such as malaria or dengue, increases risks of diarrheal diseases due to heat waves causing reduced access to safe water, and increases probability of heat waves that causes higher mortality related to cardiovasculare or chronic respiratory diseases [^2]. It is modelized following excess mortality function associated with climate change:
-$$\widetilde{DR}_i = {DR}_i [ 1 + \sum_{\mathclap{j \in J}} \alpha_{i,j} (\frac{T}{T^0})^{\theta}]$$
+```math
+\widetilde{DR}_i = {DR}_i [ 1 + \sum_{\mathclap{j \in J}} \alpha_{i,j} (\frac{T}{T^0})^{\theta}]
+```
 
 with $\alpha_{i,j}$ the relative increase in the probability of dying due to risk $j$ for the age-group $i$, calibration_temperature_increase corresponding to $T_0$ the temperature change of +2.5 Celcius degrees in 2050 for the A1b scenario used in the WHO study[^3], and $\theta$ specifies the dependence of the probability of dying with respect to temperature.
 Variable climate_mortality_param_df is the calibrated parameter value (Table 7) corresponding to: 
@@ -68,9 +70,13 @@ $$\beta_i := \sum_{\mathclap{j \in J}} \alpha_{i,j}$$
 ![](climate_death_multipliers.PNG)
 
 Finally [^10], death rate is impacted by average calorie intake and deviating from a parametrable reference value will have a significant impact on death rate in both ways. Death rate age range is impacted differently whether the average calorie intake rises or decreases: younger people will be more impacted by undernutrition whereas older one by overnutrition due to cardiovascular deseases [^11]. It is modelized such as:
-$$DR_i = \widetilde{DR}_i + \overline{DR}_i$$
+```math
+DR_i = \widetilde{DR}_i + \overline{DR}_i
+```
 with $\widetilde{DR}_i$ death rate related to economy and temperature, $\overline{DR}_i$ related to calorie intake.
-$$\overline{DR}_i = \alpha_{i,j}*|\frac{kcal-kcal_{ref}}{\theta*kcal_{ref}}|$$
+```math
+\overline{DR}_i = \alpha_{i,j}*|\frac{kcal-kcal_{ref}}{\theta*kcal_{ref}}|
+```
 with $kcal$ average food intake per capita per day, $kcal_ref$ food intake recommended per capita per day, $\alpha$ relative increase in the probability of dying due to risk j for age-group i, $\theta$ fitting value.
 
 The following table shows the relative increase in mortality $\alpha$:
@@ -100,7 +106,9 @@ The following table shows the relative increase in mortality $\alpha$:
 |100+|1|0.2|
 
 To avoid death rate greater than 1 and non physical behavior, we use a logistic function:
-$$\overline{DR}_i = \frac{1-\widetilde{DR}_i}{1+e^{-\overline{DR}_i}}$$
+```math
+\overline{DR}_i = \frac{1-\widetilde{DR}_i}{1+e^{-\overline{DR}_i}}
+```
 
 We then have one death rate per age category and per year. 
 Having a different GDP from McIsaac (2017)[^1] we could not use values of parameters from the paper so we fitted the death using data detailed in the data section bellow. 

--- a/climateeconomics/sos_wrapping/sos_wrapping_witness/population/documentation/population_discipline.md
+++ b/climateeconomics/sos_wrapping/sos_wrapping_witness/population/documentation/population_discipline.md
@@ -15,8 +15,10 @@ In order to compute the number of deaths and births we use a birth rate and a de
 
 ## Birth rate 
 According to the United Nation definition, the  age-specific birth rate is the "number of births to women in a particular age group, divided by the number of women in that age group". In our model, we look at the birth rate for the 15-49 age group, the young active population in childbearing age. 
-The birth rate is then: 
-$$birth\_rate_{15-49, t} = \frac{I_{t}}{N_{15-49, t}}$$
+The birth rate is then:
+```math
+birth\_rate_{15-49, t} = \frac{I_{t}}{N_{15-49, t}}
+```
 The birth rate depends on Gross World Product, population and knowledge: 
 $$birth\_rate_{15-49, t} = a.birth\_rate(knowledge)_t + (1-a)*birth\_rate(gdp\_capita)_t$$
 The fitting of this function is explained in the section below.   

--- a/climateeconomics/sos_wrapping/sos_wrapping_witness/population/documentation/population_discipline.md
+++ b/climateeconomics/sos_wrapping/sos_wrapping_witness/population/documentation/population_discipline.md
@@ -16,7 +16,7 @@ In order to compute the number of deaths and births we use a birth rate and a de
 ## Birth rate 
 According to the United Nation definition, the  age-specific birth rate is the "number of births to women in a particular age group, divided by the number of women in that age group". In our model, we look at the birth rate for the 15-49 age group, the young active population in childbearing age. 
 The birth rate is then: 
-$$birth\\_rate_{15-49, t} = \frac{I_{t}}{N_{15-49, t}}$$
+$$birth\_rate_{15-49, t} = \frac{I_{t}}{N_{15-49, t}}$$
 The birth rate depends on Gross World Product, population and knowledge: 
 $$birth\_rate_{15-49, t} = a.birth\_rate(knowledge)_t + (1-a)*birth\_rate(gdp\_capita)_t$$
 The fitting of this function is explained in the section below.   

--- a/climateeconomics/sos_wrapping/sos_wrapping_witness/population/documentation/population_discipline.md
+++ b/climateeconomics/sos_wrapping/sos_wrapping_witness/population/documentation/population_discipline.md
@@ -29,6 +29,7 @@ The function looks like:
  ![](knowledgefunction.png)  
 
 And then: 
+
 $$birth\_rate(knowledge)_t = c + \alpha * (1- \frac{knowledge_t}{100})^{\beta}$$
 with $c$, $\alpha$ and $\beta$ the parameters obtained by the fitting of the full birth rate function.   
 For the second part we follow McIsaac (2017)[^1]:

--- a/climateeconomics/sos_wrapping/sos_wrapping_witness/population/documentation/population_discipline.md
+++ b/climateeconomics/sos_wrapping/sos_wrapping_witness/population/documentation/population_discipline.md
@@ -58,6 +58,8 @@ death\_rate_{i, t} = dr\_upper_i + \frac{dr\_lower_i - dr\_upper_i}{(1 + \exp(-\
 ```
 where $Y_t$ represents the GDP, $N_t$ the total population at year $t$, $dr{\textunderscore}upper$ and $dr{\textunderscore}lower$ the upper and lower asymptotes, $\delta$ a slope parameter, $\phi$ is the GWP/capita value determining the inflection point and $\nu$ is a parameter that controls the curvature of the function near the asymptotes.
 
+In 2021 the novel coronavirus COVID-19 has become endemic, killing millions of people around the world and disabling countless others who suffer the symptoms known as Long Covid.  While vaccines have been successful at reducing hospitalizations and death rates, there appears to be no long-lasting COVID immunity, and each successive COVID infection appears to be as likely to kill or disable those re-infected as when they were first infected.  The cumulative probabilities of such risks are non-trivial on a global basis.  To model death rates (per 100,000) by age, we use CDC data[^11] (and will look for world-wide sources in a future update).
+
 Death rate is also impacted by climate in four principal ways, global warming affects crops by reducing yields and the micro/macronutrients contents of cereals, favors allergens and vector-borne infectious diseases such as malaria or dengue, increases risks of diarrheal diseases due to heat waves causing reduced access to safe water, and increases probability of heat waves that causes higher mortality related to cardiovasculare or chronic respiratory diseases[^2]. It is modelized following excess mortality function associated with climate change:
 ```math
 \widetilde{DR}_i = {DR}_i [ 1 + \sum_{\mathclap{j \in J}} \alpha_{i,j} (\frac{T}{T^0})^{\theta}]
@@ -116,6 +118,8 @@ Having a different GDP from McIsaac (2017)[^1] we could not use values of parame
 ## Working age population
 The working age population is the population in age to work, it is the sum of population in the 15-70 age range.
 
+When modeling the effects of COVID-19, we calculate the fraction of the population estimated to be affected by Long Covid (by age [^12]) and thus unable to work.
+
 ## Life expectancy
 Life expectancy at birth is the age-averaged proportion of surviving people:
 
@@ -164,3 +168,7 @@ The following graphs show the results of our birth rate fitting:
 [^9]: Vollset, S.E., Goren, E., Yuan, C.W., Cao, J., Smith, A.E., Hsiao, T., Bisignano, C., Azhar, G.S., Castro, E., Chalek, J. and Dolgert, A.J., 2020. Fertility, mortality, migration, and population scenarios for 195 countries and territories from 2017 to 2100: a forecasting analysis for the Global Burden of Disease Study. The Lancet, 396(10258), pp.1285-1306.
 
 [^10]: MISSING REFERENCE
+
+[^11]: Ahmad FB, Cisewski JA, Xu J, Anderson RN. COVID-19 Mortality Update — United States, 2022. MMWR Morb Mortal Wkly Rep 2023;72:493–496. DOI: http://dx.doi.org/10.15585/mmwr.mm7218a4
+
+[^12]: Adjaye-Gbewonyo D, Vahratian A, Perrine CG, Bertolli J. Long COVID in adults: United States, 2022. NCHS Data Brief, no 480. Hyattsville, MD: National Center for Health Statistics. 2023. DOI: https://dx.doi.org/10.15620/cdc:132417

--- a/climateeconomics/sos_wrapping/sos_wrapping_witness/population/documentation/population_discipline.md
+++ b/climateeconomics/sos_wrapping/sos_wrapping_witness/population/documentation/population_discipline.md
@@ -29,7 +29,7 @@ Compared to McIsaac (2017)[^1] we added a variable $knowledge$ to the equation. 
 ```math
 knowledge_t =  know\_upper + \frac{know\_lower - know\_upper}{(1 + \exp(-\delta (t - 1800 - \phi)))^{\frac{1}{\nu}}}
 ```
-with t the year at which we estimate the variable, 1800 the first year of the regression. $know{\_}upper$ and $know{\_}lower$ the upper and lower asymptotes, $\delta$ a slope parameter, $\phi$ is the year value determining the inflection point and $\nu$ is a parameter that controls the curvature of the function near the asymptotes. 
+with t the year at which we estimate the variable, 1800 the first year of the regression. $know{\textunderscore}upper$ and $know{\textunderscore}lower$ the upper and lower asymptotes, $\delta$ a slope parameter, $\phi$ is the year value determining the inflection point and $\nu$ is a parameter that controls the curvature of the function near the asymptotes. 
   
 The function looks like:   
  ![](knowledgefunction.png)  
@@ -43,7 +43,7 @@ For the second part we follow McIsaac (2017)[^1]:
 ```math
 birth\_rate(gdp\_capita)_{15-49, t} = br\_upper + \frac{br\_lower - br\_upper}{(1 + \exp(-\delta (\frac{Y_t}{N_t}-\phi)))^{\frac{1}{\nu}}}
 ```
-where $Y_t$ represents the GDP, $N_t$ the total population at year $t$, $br{\_}upper$ and $br{\_}lower$ the upper and lower asymptotes, $\delta$ a slope parameter, $\phi$ is the GWP/capita value determining the inflection point and $\nu$ is a parameter that controls the curvature of the function near the asymptotes.  
+where $Y_t$ represents the GDP, $N_t$ the total population at year $t$, $br{\textunderscore}upper$ and $br{\textunderscore}lower$ the upper and lower asymptotes, $\delta$ a slope parameter, $\phi$ is the GWP/capita value determining the inflection point and $\nu$ is a parameter that controls the curvature of the function near the asymptotes.  
 
 
 ## Death rate 
@@ -56,7 +56,7 @@ Following McIsaac (2017)[^1], and similarly to birth rate, the death rate per ag
 ```math
 death\_rate_{i, t} = dr\_upper_i + \frac{dr\_lower_i - dr\_upper_i}{(1 + \exp(-\delta_i (\frac{Y_t}{N_t} - \phi_i)))^{\frac{1}{\nu_i}}}
 ```
-where $Y_t$ represents the GDP, $N_t$ the total population at year $t$, $dr{\_}upper$ and $dr{\_}lower$ the upper and lower asymptotes, $\delta$ a slope parameter, $\phi$ is the GWP/capita value determining the inflection point and $\nu$ is a parameter that controls the curvature of the function near the asymptotes.
+where $Y_t$ represents the GDP, $N_t$ the total population at year $t$, $dr{\textunderscore}upper$ and $dr{\textunderscore}lower$ the upper and lower asymptotes, $\delta$ a slope parameter, $\phi$ is the GWP/capita value determining the inflection point and $\nu$ is a parameter that controls the curvature of the function near the asymptotes.
 
 Death rate is also impacted by climate in four principal ways, global warming affects crops by reducing yields and the micro/macronutrients contents of cereals, favors allergens and vector-borne infectious diseases such as malaria or dengue, increases risks of diarrheal diseases due to heat waves causing reduced access to safe water, and increases probability of heat waves that causes higher mortality related to cardiovasculare or chronic respiratory diseases [^2]. It is modelized following excess mortality function associated with climate change:
 $$\widetilde{DR}_i = {DR}_i [ 1 + \sum_{\mathclap{j \in J}} \alpha_{i,j} (\frac{T}{T^0})^{\theta}]$$

--- a/climateeconomics/sos_wrapping/sos_wrapping_witness/population/documentation/population_discipline.md
+++ b/climateeconomics/sos_wrapping/sos_wrapping_witness/population/documentation/population_discipline.md
@@ -20,32 +20,43 @@ The birth rate is then:
 birth\_rate_{15-49, t} = \frac{I_{t}}{N_{15-49, t}}
 ```
 The birth rate depends on Gross World Product, population and knowledge: 
-$$birth\_rate_{15-49, t} = a.birth\_rate(knowledge)_t + (1-a)*birth\_rate(gdp\_capita)_t$$
+```math
+birth\_rate_{15-49, t} = a.birth\_rate(knowledge)_t + (1-a)*birth\_rate(gdp\_capita)_t
+```
 The fitting of this function is explained in the section below.   
 Compared to McIsaac (2017)[^1] we added a variable $knowledge$ to the equation. Without it, in case of economic crisis (a decrease of gdp), the birth rate increases. We argue that in case of degrowth  we will not retrieve past level of birth rate because of all the knowledge acquired including better access to contraception, higher level of education...  Therefore we need a way to include this effect in birth rate equation. To estimate our variable $knowledge$ we use the percentage of litterate world population and do a regression on this data[^8] to fit a S-curve.
  ![](literate-and-illiterate-world-population.png)
-$$knowledge_t =  know\_upper + \frac{know\_lower - know\_upper}{(1 + \exp(-\delta (t - 1800 - \phi)))^{\frac{1}{\nu}}}$$
-with t the year at which we estimate the variable, 1800 the first year of the regression. $know\_upper$ and $know\_lower$ the upper and lower asymptotes, $\delta$ a slope parameter, $\phi$ is the year value determining the inflection point and $\nu$ is a parameter that controls the curvature of the function near the asymptotes. 
+```math
+knowledge_t =  know\_upper + \frac{know\_lower - know\_upper}{(1 + \exp(-\delta (t - 1800 - \phi)))^{\frac{1}{\nu}}}
+```
+with t the year at which we estimate the variable, 1800 the first year of the regression. $\usepackage{underscore}\usepackage[T1]{fontenc}know_upper$` and $\usepackage{underscore}\usepackage[T1]{fontenc}know\_lower$ the upper and lower asymptotes, $\delta$ a slope parameter, $\phi$ is the year value determining the inflection point and $\nu$ is a parameter that controls the curvature of the function near the asymptotes. 
   
 The function looks like:   
  ![](knowledgefunction.png)  
 
 And then: 
-
-$$birth\_rate(knowledge)_t = c + \alpha * (1- \frac{knowledge_t}{100})^{\beta}$$
+```math
+birth\_rate(knowledge)_t = c + \alpha * (1- \frac{knowledge_t}{100})^{\beta}
+```
 with $c$, $\alpha$ and $\beta$ the parameters obtained by the fitting of the full birth rate function.   
 For the second part we follow McIsaac (2017)[^1]:
-$$birth\_rate(gdp\_capita)_{15-49, t} = br\_upper + \frac{br\_lower - br\_upper}{(1 + \exp(-\delta (\frac{Y_t}{N_t}-\phi)))^{\frac{1}{\nu}}}$$
-where $Y_t$ represents the GDP, $N_t$ the total population at year $t$, $br\_upper$ and $br\_lower$ the upper and lower asymptotes, $\delta$ a slope parameter, $\phi$ is the GWP/capita value determining the inflection point and $\nu$ is a parameter that controls the curvature of the function near the asymptotes.  
+```math
+birth\_rate(gdp\_capita)_{15-49, t} = br\_upper + \frac{br\_lower - br\_upper}{(1 + \exp(-\delta (\frac{Y_t}{N_t}-\phi)))^{\frac{1}{\nu}}}
+```
+where $Y_t$ represents the GDP, $N_t$ the total population at year $t$, $\usepackage{underscore}\usepackage[T1]{fontenc}br\_upper$ and $\usepackage{underscore}\usepackage[T1]{fontenc}br\_lower$ the upper and lower asymptotes, $\delta$ a slope parameter, $\phi$ is the GWP/capita value determining the inflection point and $\nu$ is a parameter that controls the curvature of the function near the asymptotes.  
 
 
 ## Death rate 
 The death rate is the number of deaths divided by the number of persons in a specific age category and year. The death rate for age category $i$ and year $t$ is then:
-$$death\_rate_{i, t} = \frac{D_{i, t}}{N_{i, t}}$$
+```math
+death\_rate_{i, t} = \frac{D_{i, t}}{N_{i, t}}
+```
 with D the number of death and N the population. 
 Following McIsaac (2017)[^1], and similarly to birth rate, the death rate per age category $i$  and year $t$ depends on Gross World Product and on population so that: 
-$$death\_rate_{i, t} = dr\_upper_i + \frac{dr\_lower_i - dr\_upper_i}{(1 + \exp(-\delta_i (\frac{Y_t}{N_t} - \phi_i)))^{\frac{1}{\nu_i}}}$$
-where $Y_t$ represents the GDP, $N_t$ the total population at year $t$, $dr\_upper$ and $dr\_lower$ the upper and lower asymptotes, $\delta$ a slope parameter, $\phi$ is the GWP/capita value determining the inflection point and $\nu$ is a parameter that controls the curvature of the function near the asymptotes.
+```math
+death\_rate_{i, t} = dr\_upper_i + \frac{dr\_lower_i - dr\_upper_i}{(1 + \exp(-\delta_i (\frac{Y_t}{N_t} - \phi_i)))^{\frac{1}{\nu_i}}}
+```
+where $Y_t$ represents the GDP, $N_t$ the total population at year $t$, $\usepackage{underscore}\usepackage[T1]{fontenc}dr\_upper$ and $\usepackage{underscore}\usepackage[T1]{fontenc}dr\_lower$ the upper and lower asymptotes, $\delta$ a slope parameter, $\phi$ is the GWP/capita value determining the inflection point and $\nu$ is a parameter that controls the curvature of the function near the asymptotes.
 
 Death rate is also impacted by climate in four principal ways, global warming affects crops by reducing yields and the micro/macronutrients contents of cereals, favors allergens and vector-borne infectious diseases such as malaria or dengue, increases risks of diarrheal diseases due to heat waves causing reduced access to safe water, and increases probability of heat waves that causes higher mortality related to cardiovasculare or chronic respiratory diseases [^2]. It is modelized following excess mortality function associated with climate change:
 $$\widetilde{DR}_i = {DR}_i [ 1 + \sum_{\mathclap{j \in J}} \alpha_{i,j} (\frac{T}{T^0})^{\theta}]$$
@@ -56,7 +67,7 @@ $$\beta_i := \sum_{\mathclap{j \in J}} \alpha_{i,j}$$
 
 ![](climate_death_multipliers.PNG)
 
-inally [^10], death rate is impacted by average calorie intake and deviating from a parametrable reference value will have a significant impact on death rate in both ways. Death rate age range is impacted differently whether the average calorie intake rises or decreases: younger people will be more impacted by undernutrition whereas older one by overnutrition due to cardiovascular deseases [^11]. It is modelized such as:
+Finally [^10], death rate is impacted by average calorie intake and deviating from a parametrable reference value will have a significant impact on death rate in both ways. Death rate age range is impacted differently whether the average calorie intake rises or decreases: younger people will be more impacted by undernutrition whereas older one by overnutrition due to cardiovascular deseases [^11]. It is modelized such as:
 $$DR_i = \widetilde{DR}_i + \overline{DR}_i$$
 with $\widetilde{DR}_i$ death rate related to economy and temperature, $\overline{DR}_i$ related to calorie intake.
 $$\overline{DR}_i = \alpha_{i,j}*|\frac{kcal-kcal_{ref}}{\theta*kcal_{ref}}|$$
@@ -101,7 +112,9 @@ The working age population is the population in age to work, it is the sum of po
 Life expectancy at birth is the age-averaged proportion of surviving people:
 
 with $d_n$ the death rate at age $n$, and $s_n$ the surviving rate at age $n$ the life expectancy is:
-$$life\_expectancy = \sum_{\mathclap{1\le n\le 100}} s_n$$
+```math
+life\_expectancy = \sum_{\mathclap{1\le n\le 100}} s_n
+```
 
 Surviving rate is calculated as:
 $$s_{n+1} = s_n * (1 - d_n)$$

--- a/documentation/how_to_model_a_study.md
+++ b/documentation/how_to_model_a_study.md
@@ -15,7 +15,7 @@ title: Study
 ---
 flowchart LR
     di[(Data In)] -- data --> d1[Discipline 1]
-    subgraph ExcutionEngine
+    subgraph ExecutionEngine
       d1 -- data --> d2[Discipline 2]
       d2 -- data --> ddots([...])
       ddots -- data --> dn[Discipline N]
@@ -151,7 +151,7 @@ processing. An example of coupling is shown on the diagram below.
 flowchart LR
   di1([ ])
   di2([ ])
-  subgraph ExcutionEngine
+  subgraph ExecutionEngine
     d1[Discipline 1]
     d2[Discipline 2]
     d3[Discipline 3]

--- a/documentation/how_to_model_a_study.md
+++ b/documentation/how_to_model_a_study.md
@@ -10,23 +10,17 @@ Individual processing steps are called *disciplines*.
 The diagram below shows components of a study.
 
 ```mermaid
+---
+title: Study
+---
 flowchart LR
-  subgraph Study
-    di[(Data In)]
+    di[(Data In)] -- data --> d1[Discipline 1]
     subgraph ExcutionEngine
-      d1[Discipline 1]
-      d2[Discipline 2]
-      ddots([...])
-      dn[Discipline N]
+      d1 -- data --> d2[Discipline 2]
+      d2 -- data --> ddots([...])
+      ddots -- data --> dn[Discipline N]
     end
-    do[(Data Out)]
-  end
-
-  di-->|data|d1
-  d1-->|data|d2
-  d2-->|data|ddots
-  ddots-->|data|dn
-  dn-->|data|do
+    dn -- data --> do[(Data Out)]
 ```
 
 The steps to model a study are:


### PR DESCRIPTION
What follows are a collection of documentation fixes related to integrating a new model into a study.

The diagram in `how_to_model_a_study.md` doesn't print LR as indented.  Now fixed.